### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete multi-character sanitization

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@playwright/test": "^1.55.0",
     "hono": "^4.9.7",
-    "stripe": "^15.8.0"
+    "stripe": "^15.8.0",
+    "html-to-text": "^9.0.5"
   },
   "devDependencies": {
     "wrangler": "^4.32.0"

--- a/api/src/services/emailService.js
+++ b/api/src/services/emailService.js
@@ -1,6 +1,7 @@
 // Email Service for VoidCat Grant Automation Platform
 // Supports MailChannels (Cloudflare Workers) and Resend
 
+import { convert } from 'html-to-text';
 /**
  * Email service configuration and provider selection
  */
@@ -184,16 +185,14 @@ export class EmailService {
    */
   htmlToText(html) {
     if (!html) return '';
-    
-    return html
-      .replace(/<br\s*\/?>/gi, '\n')
-      .replace(/<\/p>/gi, '\n\n')
-      .replace(/<[^>]*>/g, '')
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&amp;/g, '&')
-      .trim();
+    // Use robust html-to-text library to prevent incomplete sanitization
+    return convert(html, {
+      wordwrap: false, // avoid wrapping lines
+      selectors: [ // preserve newlines for <br> and <p>
+        { selector: 'br', format: 'lineBreak' },
+        { selector: 'p', format: 'paragraph' }
+      ]
+    }).trim();
   }
 
   /**


### PR DESCRIPTION
Potential fix for [https://github.com/sorrowscry86/voidcat-grant-automation/security/code-scanning/9](https://github.com/sorrowscry86/voidcat-grant-automation/security/code-scanning/9)

The best way to fix the issue is to use a well-established library for sanitizing and converting HTML to plain text instead of writing a fragile regex-based function. This approach will handle multi-character and nested tag patterns robustly, removing all HTML tags, including dangerous ones (like `<script>`), and converting basic markup to readable text.

The `html-to-text` npm package is widely used for converting HTML to plain text. It is robust, handles edge cases, and does not simply use regexes.  
- **Change:**  
  1. At the top of the file, import the `html-to-text` library.
  2. Replace the implementation of the `htmlToText` method (lines 185-197) to delegate HTML-to-text conversion to `html-to-text`.  
- **If external libraries are forbidden:** Implement an iterative regex-replace until all tags are gone, but that is not recommended.

**Files/Regions to change:**  
- api/src/services/emailService.js
  - Add import for `html-to-text`
  - Replace lines 185-197 (function `htmlToText`) to use the library function

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
