### PR TITLE
Potential fix for code scanning alert no. 17: Creating biased random numbers from a cryptographically secure source

### DIFF
--- a/api/src/services/passwordService.js
+++ b/api/src/services/passwordService.js
@@ -151,6 +151,19 @@ export class PasswordService {
   /**
    * Generate a secure random password
    */
+
+  // Helper to get unbiased random int for a given max (exclusive)
+  getSecureRandomInt(max) {
+    if (max < 1 || max > 256) throw new Error('Invalid max for random int');
+    // rejection sampling
+    let rand;
+    const limit = Math.floor(256 / max) * max;
+    do {
+      rand = crypto.getRandomValues(new Uint8Array(1))[0];
+    } while (rand >= limit);
+    return rand % max;
+  }
+
   generateSecurePassword(length = 16) {
     const lowercase = 'abcdefghijklmnopqrstuvwxyz';
     const uppercase = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
@@ -159,24 +172,21 @@ export class PasswordService {
     
     const allChars = lowercase + uppercase + numbers + specialChars;
     
-    // Generate cryptographically secure random bytes
-    const randomBytes = crypto.getRandomValues(new Uint8Array(length));
-    
-    // Ensure at least one character from each category
+    // Ensure at least one character from each category using unbiased random
     let passwordChars = [];
-    passwordChars.push(lowercase[randomBytes[0] % lowercase.length]);
-    passwordChars.push(uppercase[randomBytes[1] % uppercase.length]);
-    passwordChars.push(numbers[randomBytes[2] % numbers.length]);
-    passwordChars.push(specialChars[randomBytes[3] % specialChars.length]);
+    passwordChars.push(lowercase[this.getSecureRandomInt(lowercase.length)]);
+    passwordChars.push(uppercase[this.getSecureRandomInt(uppercase.length)]);
+    passwordChars.push(numbers[this.getSecureRandomInt(numbers.length)]);
+    passwordChars.push(specialChars[this.getSecureRandomInt(specialChars.length)]);
     
-    // Fill the rest randomly
+    // Fill the rest randomly (unbiased)
     for (let i = 4; i < length; i++) {
-      passwordChars.push(allChars[randomBytes[i] % allChars.length]);
+      passwordChars.push(allChars[this.getSecureRandomInt(allChars.length)]);
     }
     
-    // Shuffle the password using a cryptographically secure Fisher-Yates shuffle
+    // Shuffle the password using a cryptographically secure Fisher-Yates shuffle (unbiased)
     for (let i = passwordChars.length - 1; i > 0; i--) {
-      const j = randomBytes[i] % (i + 1);
+      const j = this.getSecureRandomInt(i + 1);
       [passwordChars[i], passwordChars[j]] = [passwordChars[j], passwordChars[i]];
     }
     return passwordChars.join('');


### PR DESCRIPTION
Potential fix for [https://github.com/sorrowscry86/voidcat-grant-automation/security/code-scanning/17](https://github.com/sorrowscry86/voidcat-grant-automation/security/code-scanning/17)

The best fix is to avoid using the modulo operation directly on random bytes from `crypto.getRandomValues` when mapping to character positions, and instead use a technique called "rejection sampling" that discards values outside an evenly divisible range. Alternatively, use a well-tested library (if allowed) for password generation, but per instructions, we should operate only within the shown code.

We'll create a helper function (e.g., `getSecureRandomInt(max)`) which will get random bytes, and only return a value if it is less than `floor(256 / max) * max`, ensuring a uniform distribution for values in the range `[0, max-1]`. We'll modify lines in `generateSecurePassword` such that every index selection uses this helper instead of the modulo operator. This involves replacing lines selecting random indices for each character category (lines 167-170), for the fill loop (line 174), and for the Fisher-Yates shuffle (line 179).

We'll define the helper function inside the class above `generateSecurePassword`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
